### PR TITLE
Fix Python 3.13 builds on macOS

### DIFF
--- a/cpython-unix/build-cpython.sh
+++ b/cpython-unix/build-cpython.sh
@@ -444,6 +444,12 @@ if [ "${PYBUILD_PLATFORM}" = "macos" ]; then
     export MACOSX_DEPLOYMENT_TARGET="${APPLE_MIN_DEPLOYMENT_TARGET}"
 fi
 
+# ptsrname_r is only available in SDK 13.4+
+if [ "${PYBUILD_PLATFORM}" = "macos" ]; then
+    echo "Disabling ptsname_r due to macOS SDK 13.4+ requirement."
+    CONFIGURE_FLAGS="${CONFIGURE_FLAGS} ac_cv_func_ptsname_r=no"
+fi
+
 # We use ndbm on macOS and BerkeleyDB elsewhere.
 if [ "${PYBUILD_PLATFORM}" = "macos" ]; then
     CONFIGURE_FLAGS="${CONFIGURE_FLAGS} --with-dbmliborder=ndbm"

--- a/cpython-unix/build-cpython.sh
+++ b/cpython-unix/build-cpython.sh
@@ -146,6 +146,12 @@ if [ -n "${PYTHON_MEETS_MAXIMUM_VERSION_3_10}" ]; then
   patch -p1 -i ${ROOT}/patch-makesetup-deduplicate-objs.patch
 fi
 
+# testembed links against Tcl/Tk and libpython which already has Tcl/Tk leading
+# duplicate symbols and warnings from objc (which causes test failures).
+if [ -n "${PYTHON_MEETS_MAXIMUM_VERSION_3_13}" ]; then
+  patch -p1 -i ${ROOT}/patch-make-testembed-nolink-tcltk.patch
+fi
+
 # The default build rule for the macOS dylib doesn't pick up libraries
 # from modules / makesetup. So patch it accordingly.
 if [ -n "${PYTHON_MEETS_MINIMUM_VERSION_3_13}" ]; then

--- a/cpython-unix/patch-make-testembed-nolink-tcltk.patch
+++ b/cpython-unix/patch-make-testembed-nolink-tcltk.patch
@@ -1,0 +1,10 @@
+diff --git a/Makefile.pre.in b/Makefile.pre.in
+--- a/Makefile.pre.in
++++ b/Makefile.pre.in
+@@ -1432,6 +1432,8 @@
+ 	$(RUNSHARED) ./$(BUILDPYTHON) $(srcdir)/Tools/build/generate_re_casefix.py $(srcdir)/Lib/re/_casefix.py
+
+ Programs/_testembed: Programs/_testembed.o $(LINK_PYTHON_DEPS)
++	$(eval MODLIBS := $(subst -Xlinker -hidden-ltcl8.6, , $(MODLIBS)))
++	$(eval MODLIBS := $(subst -Xlinker -hidden-ltk8.6, , $(MODLIBS)))
+ 	$(LINKCC) $(PY_CORE_LDFLAGS) $(LINKFORSHARED) -o $@ Programs/_testembed.o $(LINK_PYTHON_OBJS) $(LIBS) $(MODLIBS) $(SYSLIBS)

--- a/cpython-unix/targets.yml
+++ b/cpython-unix/targets.yml
@@ -566,7 +566,7 @@ x86_64-apple-darwin:
   target_cflags:
     - '-arch'
     - 'x86_64'
-    - '-mmacosx-version-min=10.13.4'
+    - '-mmacosx-version-min=10.13'
     # Suppress extremely verbose warnings we see with LLVM 10.
     - '-Wno-nullability-completeness'
     - '-Wno-expansion-to-defined'
@@ -581,7 +581,7 @@ x86_64-apple-darwin:
   target_ldflags:
     - '-arch'
     - 'x86_64'
-    - '-mmacosx-version-min=10.13.4'
+    - '-mmacosx-version-min=10.13'
   needs:
     - autoconf
     - bzip2

--- a/cpython-unix/targets.yml
+++ b/cpython-unix/targets.yml
@@ -546,7 +546,7 @@ thumb7k-apple-watchos:
 
 # Intel macOS.
 #
-# We target compatibility with macOS 10.13+ for compatibility with older Apple
+# We target compatibility with macOS 10.9+ for compatibility with older Apple
 # machines.
 x86_64-apple-darwin:
   host_platforms:
@@ -566,7 +566,7 @@ x86_64-apple-darwin:
   target_cflags:
     - '-arch'
     - 'x86_64'
-    - '-mmacosx-version-min=10.13'
+    - '-mmacosx-version-min=10.9'
     # Suppress extremely verbose warnings we see with LLVM 10.
     - '-Wno-nullability-completeness'
     - '-Wno-expansion-to-defined'
@@ -581,7 +581,7 @@ x86_64-apple-darwin:
   target_ldflags:
     - '-arch'
     - 'x86_64'
-    - '-mmacosx-version-min=10.13'
+    - '-mmacosx-version-min=10.9'
   needs:
     - autoconf
     - bzip2

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -1100,7 +1100,7 @@ fn validate_macho<Mach: MachHeader<Endian = Endianness>>(
     bytes: &[u8],
 ) -> Result<()> {
     let advertised_target_version =
-        semver::Version::parse(&format!("{}", advertised_target_version))?;
+        semver::Version::parse(&format!("{}.0", advertised_target_version))?;
     let advertised_sdk_version = semver::Version::parse(&format!("{}.0", advertised_sdk_version))?;
 
     let endian = header.endian()?;

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -461,7 +461,7 @@ static PLATFORM_TAG_BY_TRIPLE: Lazy<HashMap<&'static str, &'static str>> = Lazy:
         ("mips64el-unknown-linux-gnuabi64", "todo"),
         ("ppc64le-unknown-linux-gnu", "linux-powerpc64le"),
         ("s390x-unknown-linux-gnu", "linux-s390x"),
-        ("x86_64-apple-darwin", "macosx-10.13-x86_64"),
+        ("x86_64-apple-darwin", "macosx-10.9-x86_64"),
         ("x86_64-apple-ios", "iOS-x86_64"),
         ("x86_64-pc-windows-msvc", "win-amd64"),
         ("x86_64-unknown-linux-gnu", "linux-x86_64"),


### PR DESCRIPTION
Split from https://github.com/zanieb/python-build-standalone/pull/6 explicitly exploring macOS builds